### PR TITLE
Add new Z - Offset macro to the QC process

### DIFF
--- a/macros/Auto Calibration
+++ b/macros/Auto Calibration
@@ -36,6 +36,11 @@ M42 P4 S1                                              ; Turn on relay
 M98 P"0:/macros/System/Calibration/QC/AutoCal/Tool Height Auto Calibration" A1
 M400
 
+; Check if this is not a QC process and run Z - Offset Calibration
+if exists(global.is_qc_active) && global.is_qc_active == false
+  M98 P"0:/macros/System/Calibration/QC/AutoCal/Z - Offset Calibration" A1
+  M400
+
 if exists(global.xcomp_mode) && global.xcomp_mode == "manual"
   echo "Skipping Mesh Bed calibration because compensation mode is manual"
 else
@@ -93,3 +98,9 @@ set var.msg = var.msg ^ "<br>Tool 1 Y-Offset = " ^ global.yoffset ^ " mm"
 set var.msg = var.msg ^ "<br>Tool 1 U-Offset = " ^ global.uoffset ^ " mm"
 set var.msg = var.msg ^ "<br>XY Skew = " ^ global.xy_square_auto ^ " mm"
 M291 S2 R"Calibration Complete" P{var.msg}
+
+; Check if we run the QC process now and finish it
+if exists(global.is_qc_active) && global.is_qc_active == true
+  ; END of the QC process
+  set global.is_qc_active = false
+  echo >>"0:/user/is_qc_active.g" "set global.is_qc_active = "^{global.is_qc_active}

--- a/macros/Auto Calibration
+++ b/macros/Auto Calibration
@@ -103,4 +103,4 @@ M291 S2 R"Calibration Complete" P{var.msg}
 if exists(global.is_qc_active) && global.is_qc_active == true
   ; END of the QC process
   set global.is_qc_active = false
-  echo >>"0:/user/is_qc_active.g" "set global.is_qc_active = "^{global.is_qc_active}
+  echo >"0:/user/is_qc_active.g" "set global.is_qc_active = "^{global.is_qc_active}

--- a/macros/Auto Calibration
+++ b/macros/Auto Calibration
@@ -36,9 +36,6 @@ M42 P4 S1                                              ; Turn on relay
 M98 P"0:/macros/System/Calibration/QC/AutoCal/Tool Height Auto Calibration" A1
 M400
 
-M98 P"0:/macros/System/Calibration/QC/AutoCal/Z - Offset Calibration" A1
-M400
-
 if exists(global.xcomp_mode) && global.xcomp_mode == "manual"
   echo "Skipping Mesh Bed calibration because compensation mode is manual"
 else

--- a/macros/Auto Calibration
+++ b/macros/Auto Calibration
@@ -1,62 +1,9 @@
-if heat.heaters[0].state == "fault" || heat.heaters[1].state == "fault" || heat.heaters[2].state == "fault" || heat.heaters[3].state == "fault"
-  M291 S1 R"Error" P"Heater fault detected"
-  abort "Error: Heater fault detected"
-
-M291 S5 J1 F250 L0 H450 R"Set Left Tool Temperature" P"Please set the temperature for the filament previously loaded in the Left Tool.<br>If new machine, set to 250°C"
-var ll = input
-  
-M291 S5 J1 F{var.ll} L0 H450 R"Set Right Tool Temperature" P"Please set the temperature for the filament previously loaded in the Right Tool.<br>If new machine, set to 250°C"
-var rr = input
-
-var delta = -50
-
-M568 P0 R{var.ll + var.delta} S{var.ll + var.delta}
-M568 P1 R{var.rr + var.delta} S{var.rr + var.delta}
-M568 P2 R{var.ll + var.delta,var.rr + var.delta} S{var.ll + var.delta,var.rr + var.delta}
-M568 P3 R{var.ll + var.delta,var.rr + var.delta} S{var.ll + var.delta,var.rr + var.delta}
-
-M568 P0 A2
-M568 P1 A2
-
-
-M291 S2 R"Please Remove the Build Plate" P"To avoid damaging your machine, remove the build plate from the build platform.<br>Click ""OK"" when you are ready to proceed."
-
+; Home All and Clean Nozzels (WITH compensatex)
+M98 P"0:/macros/System/Calibration/QC/AutoCal/Home All and Clean Nozzels" A1 B1
+; Validate if Homing is complete, if not - it means that user cancelled the process and we have to exit
 if !move.axes[0].homed || !move.axes[1].homed || !move.axes[2].homed || !move.axes[3].homed
-  M291 S0 T15 R"Homing Axes" P"Axes are not homed. Homing now. Please wait..."
-  M98 P"0:/sys/homeall.g" S1
+  abort "Calibration cancelled by user. Axes are not homed."
 
-if state.currentTool != 0
-  T0
-
-G90
-G1 X-999 U999 Y-75 F18000
-
-M116 P0 S10
-M116 P1 S10
-
-T3
-M83                 ; relative extruder moves
-G1 E-50 F{60}*{10}   ; retract filament
-
-M98 P"0:/sys/nozzlewipe.g" C1
-M400
-while iterations < 2
-  M98 P"0:/sys/nozzlewipe.g" L1 C1
-  M400
-
-G1 F18000 X-50 Y-150 Z125  ; Move tools to the cleaning position
-
-M568 P3 A0
-
-M291 S4 K{"Nozzles are Clean","Cancel"} R"Please Clean Both Nozzles" P"Use a metal brush to clean both nozzles thoroughly to prevent machine damage."
-
-if input == 1
-  ; User cancelled
-  M568 P0 S0 R0
-  M568 P1 S0 R0
-  M568 P2 S0 R0
-  M568 P3 S0 R0
-  abort "Calibration cancelled by user"
 
 M291 S4 K{"Heat Breaks are All the Way Up","Cancel"} R"Verify Heat Breaks Position" P"Ensure both heat breaks are pushed all the way up into the heat sink.<br>They should NOT stick out more than 1mm from the heat sink."
 

--- a/macros/System/Calibration/QC/AutoCal/Home All and Clean Nozzels
+++ b/macros/System/Calibration/QC/AutoCal/Home All and Clean Nozzels
@@ -1,0 +1,66 @@
+if !exists(param.A)
+  M291 S1 T0 R"Use Auto Calibration macro" P"Using separate calibration macros may cause issues.<br>Please use the Auto Calibration macro"
+  abort "Error: Auto Calibration macro required."
+  
+if heat.heaters[0].state == "fault" || heat.heaters[1].state == "fault" || heat.heaters[2].state == "fault" || heat.heaters[3].state == "fault"
+  M291 S1 R"Error" P"Heater fault detected"
+  abort "Error: Heater fault detected"
+
+M291 S5 J1 F250 L0 H450 R"Set Left Tool Temperature" P"Please set the temperature for the filament previously loaded in the Left Tool.<br>If new machine, set to 250°C"
+var ll = input
+  
+M291 S5 J1 F{var.ll} L0 H450 R"Set Right Tool Temperature" P"Please set the temperature for the filament previously loaded in the Right Tool.<br>If new machine, set to 250°C"
+var rr = input
+
+var delta = -50
+
+M568 P0 R{var.ll + var.delta} S{var.ll + var.delta}
+M568 P1 R{var.rr + var.delta} S{var.rr + var.delta}
+M568 P2 R{var.ll + var.delta,var.rr + var.delta} S{var.ll + var.delta,var.rr + var.delta}
+M568 P3 R{var.ll + var.delta,var.rr + var.delta} S{var.ll + var.delta,var.rr + var.delta}
+
+M568 P0 A2
+M568 P1 A2
+
+
+M291 S2 R"Please Remove the Build Plate" P"To avoid damaging your machine, remove the build plate from the build platform.<br>Click ""OK"" when you are ready to proceed."
+
+if !move.axes[0].homed || !move.axes[1].homed || !move.axes[2].homed || !move.axes[3].homed
+  M291 S0 T15 R"Homing Axes" P"Axes are not homed. Homing now. Please wait..."
+  M98 P"0:/sys/homeall.g" S1
+
+; Run compensatex for Auto Calibration macro only
+if exists(param.B)
+  M98 P"0:/sys/compensatex.g"
+
+if state.currentTool != 0
+  T0
+
+G90
+G1 X-999 U999 Y-75 F18000
+
+M116 P0 S10
+M116 P1 S10
+
+T3
+M83                  ; relative extruder moves
+G1 E-50 F{60}*{10}   ; retract filament
+
+M98 P"0:/sys/nozzlewipe.g" C1
+M400
+while iterations < 2
+  M98 P"0:/sys/nozzlewipe.g" L1 C1
+  M400
+
+G1 F18000 X-50 Y-150 Z125  ; Move tools to the cleaning position
+
+M568 P3 A0
+
+M291 S4 K{"Nozzles are Clean","Cancel"} R"Please Clean Both Nozzles" P"Use a metal brush to clean both nozzles thoroughly to prevent machine damage."
+if input == 1
+  ; User cancelled
+  M568 P0 S0 R0
+  M568 P1 S0 R0
+  M568 P2 S0 R0
+  M568 P3 S0 R0
+  abort "Calibration cancelled by user"

--- a/macros/System/Calibration/QC/Test 1
+++ b/macros/System/Calibration/QC/Test 1
@@ -2,7 +2,7 @@ M98 P"0:/sys/led/resetstatus.g"
 
 ; START of the QC process
 set global.is_qc_active = true
-echo >>"0:/user/is_qc_active.g" "set global.is_qc_active = "^{global.is_qc_active}
+echo >"0:/user/is_qc_active.g" "set global.is_qc_active = "^{global.is_qc_active}
 
 ; Prompt user to confirm starting the test
 M291 R"Start Test 1" P"Do you want to start Test 1?" K{"Start Test","Cancel"} S4

--- a/macros/System/Calibration/QC/Test 1
+++ b/macros/System/Calibration/QC/Test 1
@@ -1,5 +1,9 @@
 M98 P"0:/sys/led/resetstatus.g"
 
+; START of the QC process
+set global.is_qc_active = true
+echo >>"0:/user/is_qc_active.g" "set global.is_qc_active = "^{global.is_qc_active}
+
 ; Prompt user to confirm starting the test
 M291 R"Start Test 1" P"Do you want to start Test 1?" K{"Start Test","Cancel"} S4
 

--- a/macros/System/Calibration/QC/Z - Offset
+++ b/macros/System/Calibration/QC/Z - Offset
@@ -1,0 +1,35 @@
+; Home All and Clean Nozzels (without calling compensatex)
+M98 P"0:/macros/System/Calibration/QC/AutoCal/Home All and Clean Nozzels" A1
+
+; Validate if Homing is complete, if not - it means that user cancelled the process and we have to exit
+if !move.axes[0].homed || !move.axes[1].homed || !move.axes[2].homed || !move.axes[3].homed
+  abort "Calibration cancelled by user. Axes are not homed."
+
+
+; Exit mirroring mode, use one tool:
+T0 ; select first tool
+G90 ; absolute positioning
+G1 U999 ; move U-carriage off the way (maybe add F18000 to move faster)
+
+
+; Run Z - Offset Calibration
+M98 P"0:/macros/System/Calibration/QC/AutoCal/Z - Offset Calibration" A1
+M400
+
+
+; Place the Probe
+M98 P"0:/sys/detachedcheck.g"
+
+
+; Cool down
+; TODO: this part of code is repeated at meany pace and should refactored bu moving out to a separate module
+M568 P0 S0 R0
+M568 P1 S0 R0
+M568 P2 S0 R0
+M568 P3 S0 R0
+
+
+; reset position
+; TODO: this tool can be moved to an individual file for further re-use
+G90 ; absolute positioning
+G1 X-999 U999 Y175 F18000 ; move heads to the corners

--- a/macros/System/Calibration/QC/Z - Offset
+++ b/macros/System/Calibration/QC/Z - Offset
@@ -32,4 +32,4 @@ M568 P3 S0 R0
 ; reset position
 ; TODO: this tool can be moved to an individual file for further re-use
 G90 ; absolute positioning
-G1 X-999 U999 Y175 F18000 ; move heads to the corners
+G1 X-999 U999 Y150 F18000 ; move heads to the corners

--- a/sys/config.g
+++ b/sys/config.g
@@ -176,6 +176,12 @@ if fileexists("0:/user/brushYPosition.g")
 
 echo >"0:/sys/resetzbabystep.g" "                                ; do nothing"
 
+; Define the state of QC process
+; Set it to "true" only when QC is ongoing, after QC is completed you MUST set it back to "false"
+; START of the QC is in "Test 1" macro / END of the QC is in "Auto Calibration"
+global is_qc_active = false                                     ; Declare global variable with default value
+M98 P"0:/user/is_qc_active.g"                                   ; Load previously saved state
+
 ; Custom settings
 M280 P0 S0                                                       ; rotate servo to 0 deg
 T0 P0

--- a/user/is_qc_active.g
+++ b/user/is_qc_active.g
@@ -1,0 +1,1 @@
+set global.is_qc_active = false


### PR DESCRIPTION
Added: new Z - Offset macro which should be executed during the QC process **after Test2** and **before printing Three Squares Test**.
Running Z - Offset in full Autocalibration is not required anymore.